### PR TITLE
Move licence to global table

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -7,6 +7,8 @@
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
 loaderVersion="[28,)" #mandatory (28 is current forge version)
+license="LGPL v3"
+
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod
@@ -19,7 +21,6 @@ displayName="Server Pack Locator Utility mod" #mandatory
 credits="cpw" #optional
 # A text field displayed in the mod UI
 authors="cpw" #optional
-
 license="LGPL v3"
 # The description text for the mod (multi line!) (#mandatory)
 description='''


### PR DESCRIPTION
Licenses are checked on the global object rather than per-mod. This should make things load correctly on 1.16.2+.

I left the license in [[mods]] array of tables entry as well, as it may be changed in future to support both.